### PR TITLE
initial storage and url schema docs

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -5,6 +5,14 @@
 VDisc supports reading file data from different URL schemes. These are
 documented below.
 
+## Table of Contents
+
+  * [data](#data)
+  * [file](#file)
+  * [S3](#S3)
+  * [Swift](#swift-/-s3api)
+  * [zero](#zero)
+
 ## data
 
 `data:[<media type>][;base64],<data>`
@@ -29,7 +37,7 @@ TODO
 
 TODO
 
-### Auth considerations
+### S3 Auth considerations
 
 TODO
 
@@ -57,7 +65,7 @@ The URL schema has four key parts:
 `<object>`
 :   The name of the object. The object name may include the `/` character.
 
-### Auth considerations
+### Swift Auth considerations
 
 VDisc uses the following environment variables for `swift` auth:
 

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,0 +1,77 @@
+# VDisc Storage
+
+## Background
+
+VDisc supports reading file data from different URL schemes. These are
+documented below.
+
+## Swift / s3api
+
+`swift://<endpoint>/<owner>/<container>/<object>`
+
+When talking to a Swift cluster, use the `swift` URL schema. Internally,
+this schema uses the S3 API to talk to the Swift cluster, so the Swift
+cluster needs to have enabled `s3api` support.
+
+The URL schema has four key parts:
+
+`<endpoint>`
+:   Server hostname, including port designation, if needed
+
+`<owner>`
+:   The owner of the container and object being referenced. In practice,
+    this normally ends up being the same value as the `SWIFT_ACCESS_KEY_ID`
+
+`<container>`
+:   The name of the Swift container being used. This is analagous to an S3
+    bucket.
+
+`<object>`
+:   The name of the object. The object name may include the `/` character.
+
+### Auth considerations
+
+VDisc uses the following environment variables for `swift` auth:
+
+    SWIFT_ACCESS_KEY_ID=user
+    SWIFT_SECRET_ACCESS_KEY=s3api password
+
+By default, VDisc uses the `us-east-1` region. If your Swift cluster is
+configured with a different s3api region, set the correct value in the
+`SWIFT_REGION` environment variable.
+
+
+## http
+
+`https://<endpoint>/<object>`
+
+TODO
+
+## S3
+
+`s3://<bucket>/<object>`
+
+TODO
+
+### Auth considerations
+
+TODO
+
+## zero
+
+`zero:<length>`
+
+Returns a byte stream with a fixed length. eg `zero:72` is a stream of
+72 null bytes. This is useful for testing.
+
+## data
+
+`data:[<media type>][;base64],<data>`
+
+The data URL scheme is described at https://en.wikipedia.org/wiki/Data_URI_scheme
+
+## file
+
+`file:///<path/to/local/file>`
+
+TODO

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -5,6 +5,34 @@
 VDisc supports reading file data from different URL schemes. These are
 documented below.
 
+## data
+
+`data:[<media type>][;base64],<data>`
+
+The data URL scheme is described at https://en.wikipedia.org/wiki/Data_URI_scheme
+
+## file
+
+`file:///<path/to/local/file>`
+
+TODO
+
+## http
+
+`https://<endpoint>/<object>`
+
+TODO
+
+## S3
+
+`s3://<bucket>/<object>`
+
+TODO
+
+### Auth considerations
+
+TODO
+
 ## Swift / s3api
 
 `swift://<endpoint>/<owner>/<container>/<object>`
@@ -40,38 +68,9 @@ By default, VDisc uses the `us-east-1` region. If your Swift cluster is
 configured with a different s3api region, set the correct value in the
 `SWIFT_REGION` environment variable.
 
-
-## http
-
-`https://<endpoint>/<object>`
-
-TODO
-
-## S3
-
-`s3://<bucket>/<object>`
-
-TODO
-
-### Auth considerations
-
-TODO
-
 ## zero
 
 `zero:<length>`
 
 Returns a byte stream with a fixed length. eg `zero:72` is a stream of
 72 null bytes. This is useful for testing.
-
-## data
-
-`data:[<media type>][;base64],<data>`
-
-The data URL scheme is described at https://en.wikipedia.org/wiki/Data_URI_scheme
-
-## file
-
-`file:///<path/to/local/file>`
-
-TODO

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -10,7 +10,7 @@ documented below.
   * [data](#data)
   * [file](#file)
   * [S3](#S3)
-  * [Swift](#swift-/-s3api)
+  * [Swift](#swift--s3api)
   * [zero](#zero)
 
 ## data

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -9,6 +9,7 @@ documented below.
 
   * [data](#data)
   * [file](#file)
+  * [http](#file)
   * [S3](#S3)
   * [Swift](#swift--s3api)
   * [zero](#zero)


### PR DESCRIPTION
Initial structure for documenting URL schemas and storage backend support. The Swift, zero, and data schemas are described; the others only show their respective URL template.